### PR TITLE
Upgraded pyproject.toml to PEP 621

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ build-backend = "maturin"
 [project]
 name = "cloverleaf"
 requires-python = ">=3.7"
+version = "1.0.0"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",


### PR DESCRIPTION
Since Maturin `0.14.0` pyproject.toml must follow PEP 621, which requires a version to be specified, otherwise the build fails.