### PR TITLE
Fix bug in conversion from CDF to PDF

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -457,7 +457,7 @@ impl <'a> Iterator for CDFtoP<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.idx < self.cdf.len() {
-            let p = self.prob(0);
+            let p = self.prob(self.idx);
             self.idx += 1;
             Some(p)
         } else {


### PR DESCRIPTION
CDF to PDF bug fixed, using current index rather than `prob(0)` on each iteration.