### PR TITLE
Refactor PolicyEvaluation to mutate graphs in place

### DIFF
--- a/examples/policy_evaluation.py
+++ b/examples/policy_evaluation.py
@@ -18,7 +18,6 @@ pe = cloverleaf.PolicyEvaluation(
     iterations=100,
     eps=1e-6,
     temperature=0.5,
-    indicator=True,
 )
 
 # Products get positive reward -- we want trajectories biased toward them
@@ -26,19 +25,25 @@ pe.set_reward(("prod", "widget"), 10.0)
 pe.set_reward(("prod", "gadget"), 5.0)
 pe.set_reward(("prod", "doohickey"), 2.0)
 
-new_graph = pe.optimize()
+# Snapshot edges BEFORE optimize, since optimize mutates `graph` in place.
+before = {}
+for node_type, node_name in graph.vocab():
+    nodes, weights = graph.get_edges((node_type, node_name), normalized=True)
+    if nodes:
+        before[(node_type, node_name)] = (nodes, weights)
+
+# Mutates `graph` in place.  no_copy defaults to True; we hold no other
+# references to the graph, so this runs without any copy.
+pe.optimize(graph, indicator=True)
 
 print("Edge weight changes under optimal policy:\n")
-for node_type, node_name in graph.vocab():
-    nodes_old, weights_old = graph.get_edges((node_type, node_name), normalized=True)
-    nodes_new, weights_new = new_graph.get_edges((node_type, node_name), normalized=True)
-    if not nodes_old:
-        continue
+for (node_type, node_name), (nodes_old, weights_old) in before.items():
+    nodes_new, weights_new = graph.get_edges((node_type, node_name), normalized=True)
     print(f"  {node_type}:{node_name}")
     for (_, wo), (nn, wn) in zip(zip(nodes_old, weights_old), zip(nodes_new, weights_new)):
         changed = " <--" if abs(wo - wn) > 0.001 else ""
         print(f"    -> {nn[0]}:{nn[1]:10s}  {wo:.4f} -> {wn:.4f}{changed}")
     print()
 
-new_graph.save("/tmp/pe_graph")
+graph.save("/tmp/pe_graph")
 print("Saved reweighted graph to /tmp/pe_graph")

--- a/src/algos/policy_evaluation.rs
+++ b/src/algos/policy_evaluation.rs
@@ -12,7 +12,7 @@
 use rayon::prelude::*;
 use std::fmt::Write;
 
-use crate::graph::{Graph, ModifiableGraph}; 
+use crate::graph::{Graph, ParallelModifiableGraph, convert_edges_to_cdf}; 
 use crate::progress::CLProgressBar;
 
 pub struct PolicyEvaluation {
@@ -91,7 +91,7 @@ impl PolicyEvaluation {
                 *nv = rewards[node_id] + self.gamma * expected_future_value;
             });
 
-            // Map-Reduce to find the maximum absolute error (L-infinity norm)
+            // Find the maximum absolute error (L-infinity norm)
             err = next_v
                 .par_iter()
                 .zip(v.par_iter())
@@ -113,90 +113,67 @@ impl PolicyEvaluation {
     /// Extracts a stochastic policy from the value function and updates the graph weights IN-PLACE.
     /// Blends the original transition probabilities with a softmax over neighbor values.
     pub fn update_policy_weights_in_place<G>(&self, graph: &mut G, values: &[f32])
-        where G: ModifiableGraph + Graph {
+        where G: ParallelModifiableGraph + Graph {
     
-    // Threshold for when parallelization becomes worth the overhead.
-    const PARALLEL_THRESHOLD: usize = 10_000; 
+        // Threshold for when parallelization becomes worth the overhead.
+        const PARALLEL_THRESHOLD: usize = 10_000; 
 
-    for node_id in 0..graph.len() {
-        let (edges, weights) = graph.modify_edges(node_id as _);
-        
-        // 1. In-place CDF to Probabilities (Sequential Backwards)
-        for i in (1..weights.len()).rev() {
-            // Add .max(0.0) to eradicate any floating-point drift
-            weights[i] = (weights[i] - weights[i - 1]).max(0.0);
-        }
+        graph.par_iter_mut().for_each(|(edges, weights)| {
 
-        if edges.len() >= PARALLEL_THRESHOLD {
-            // === HEAVY NODE: USE RAYON ===
-            let max_v = edges
-                .par_iter()
-                .map(|&e| values[e as usize])
-                .reduce(|| f32::NEG_INFINITY, f32::max);
-
-            let sum = if self.temperature <= f32::EPSILON {
-                edges.par_iter().zip(weights.par_iter_mut()).map(|(&edge, w)| {
-                    if (values[edge as usize] - max_v).abs() <= f32::EPSILON { *w } else { *w = 0.0; 0.0 }
-                }).sum()
-            } else {
-                edges.par_iter().zip(weights.par_iter_mut()).map(|(&edge, w)| {
-                    let exp_v = ((values[edge as usize] - max_v) / self.temperature).exp();
-                    *w *= exp_v;
-                    *w
-                }).sum()
-            };
-
-            normalize_to_cdf(weights, sum);
-
-        } else {
-            // === TYPICAL NODE: FAST SEQUENTIAL
-            let mut max_v = f32::NEG_INFINITY;
-            for &e in edges.iter() {
-                max_v = f32::max(max_v, values[e as usize]);
+            // 1. In-place CDF to Probabilities (Sequential Backwards)
+            for i in (1..weights.len()).rev() {
+                // Add .max(0.0) to eradicate any floating-point drift
+                weights[i] = (weights[i] - weights[i - 1]).max(0.0);
             }
 
-            let mut sum = 0.0;
-            if self.temperature <= f32::EPSILON {
-                for (&edge, w) in edges.iter().zip(weights.iter_mut()) {
-                    if (values[edge as usize] - max_v).abs() <= f32::EPSILON {
+            let sum = if edges.len() >= PARALLEL_THRESHOLD {
+                // === HEAVY NODE: USE RAYON ===
+                let max_v = edges
+                    .par_iter()
+                    .map(|&e| values[e as usize])
+                    .reduce(|| f32::NEG_INFINITY, f32::max);
+
+                if self.temperature <= f32::EPSILON {
+                    edges.par_iter().zip(weights.par_iter_mut()).map(|(&edge, w)| {
+                        if (values[edge as usize] - max_v).abs() <= f32::EPSILON { *w } else { *w = 0.0; 0.0 }
+                    }).sum()
+                } else {
+                    edges.par_iter().zip(weights.par_iter_mut()).map(|(&edge, w)| {
+                        let exp_v = ((values[edge as usize] - max_v) / self.temperature).exp();
+                        *w *= exp_v;
+                        *w
+                    }).sum()
+                }
+
+            } else {
+                // === TYPICAL NODE: FAST SEQUENTIAL
+                let mut max_v = f32::NEG_INFINITY;
+                for &e in edges.iter() {
+                    max_v = f32::max(max_v, values[e as usize]);
+                }
+
+                let mut sum = 0.0;
+                if self.temperature <= f32::EPSILON {
+                    for (&edge, w) in edges.iter().zip(weights.iter_mut()) {
+                        if (values[edge as usize] - max_v).abs() <= f32::EPSILON {
+                            sum += *w;
+                        } else {
+                            *w = 0.0;
+                        }
+                    }
+                } else {
+                    for (&edge, w) in edges.iter().zip(weights.iter_mut()) {
+                        let exp_v = ((values[edge as usize] - max_v) / self.temperature).exp();
+                        *w *= exp_v;
                         sum += *w;
-                    } else {
-                        *w = 0.0;
                     }
                 }
-            } else {
-                for (&edge, w) in edges.iter().zip(weights.iter_mut()) {
-                    let exp_v = ((values[edge as usize] - max_v) / self.temperature).exp();
-                    *w *= exp_v;
-                    sum += *w;
-                }
-            }
+                sum
+            };
+            // Convert back to CDF
+            convert_edges_to_cdf(weights, Some(sum));
 
-            normalize_to_cdf(weights, sum);
-        }
+        });
     }
 }
-}
 
-#[inline]
-fn normalize_to_cdf(weights: &mut [f32], sum: f32) {
-    if sum > 0.0 {
-        let mut accum = 0.0;
-        for w in weights.iter_mut() {
-            accum += *w / sum;
-            // .min(1.0) prevents intermediate values from overshooting
-            // the final 1.0 clamp, preserving monotonicity.
-            *w = accum.min(1.0);
-        }
-        if let Some(last) = weights.last_mut() {
-            *last = 1.0;
-        }
-    } else if !weights.is_empty() {
-        // Fallback: If all probabilities vanished, revert to a uniform
-        // CDF to prevent the node from becoming a broken sink.
-        let n = weights.len() as f32;
-        for (i, w) in weights.iter_mut().enumerate() {
-            *w = ((i + 1) as f32) / n;
-        }
-    }
-}

--- a/src/algos/smci.rs
+++ b/src/algos/smci.rs
@@ -175,7 +175,7 @@ fn interpolate_edges(alpha: f32, g: &impl CDFGraph, weights: &mut [f32]) {
             t.push(w);
         });
         nw.clone_from_slice(&t);
-        convert_edges_to_cdf(&mut nw);
+        convert_edges_to_cdf(&mut nw, None);
     }
 }
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -5,6 +5,8 @@
 //! copy.
 
 use rayon::prelude::ParallelSliceMut;
+use rayon::iter::{IndexedParallelIterator, ParallelIterator};
+use rayon::iter::plumbing::{bridge, Consumer, Producer, ProducerCallback, UnindexedConsumer};
 
 pub type NodeID = usize;
 
@@ -30,6 +32,13 @@ pub trait Graph {
 pub trait ModifiableGraph {
     /// Get edges and corresponding weights
     fn modify_edges(&mut self, idx: NodeID) -> (&mut [NodeID], &mut [f32]);
+}
+
+/// trait which allows graphs to be updated in parallel.  Implementors must expose per-node
+/// edge and weight slices that live in disjoint regions of flat backing buffers.
+pub trait ParallelModifiableGraph: ModifiableGraph {
+    /// Parallel iterator yielding `(&mut edges, &mut weights)` per node, in node order.
+    fn par_iter_mut(&mut self) -> CSRParIterMut<'_>;
 }
 
 /// Trait which transposes a graph's adjacency list
@@ -99,6 +108,15 @@ impl CSR {
         CSR { rows, columns, weights: data }
     }
 
+    /// Parallel mutable access to each node's edge and weight slices.
+    pub fn par_iter_mut(&mut self) -> CSRParIterMut<'_> {
+        CSRParIterMut {
+            rows: &self.rows,
+            columns: &mut self.columns,
+            weights: &mut self.weights,
+        }
+    }
+
     fn deduplicate_edges(
         edges: &mut Vec<(NodeID, NodeID, f32)>
     ) -> () {
@@ -164,6 +182,147 @@ impl ModifiableGraph for CSR {
 
 }
 
+impl ParallelModifiableGraph for CSR {
+    fn par_iter_mut(&mut self) -> CSRParIterMut<'_> {
+        CSR::par_iter_mut(self)
+    }
+}
+
+/// Zero-allocation parallel iterator over each node's mutable edge and weight slices.
+/// Splits via rayon are O(1) — we carve the flat CSR buffers with split_at_mut.
+pub struct CSRParIterMut<'a> {
+    rows: &'a [NodeID],
+    columns: &'a mut [NodeID],
+    weights: &'a mut [f32],
+}
+
+impl<'a> ParallelIterator for CSRParIterMut<'a> {
+    type Item = (&'a mut [NodeID], &'a mut [f32]);
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+    where
+        C: UnindexedConsumer<Self::Item>,
+    {
+        bridge(self, consumer)
+    }
+
+    fn opt_len(&self) -> Option<usize> {
+        Some(IndexedParallelIterator::len(self))
+    }
+}
+
+impl<'a> IndexedParallelIterator for CSRParIterMut<'a> {
+    fn len(&self) -> usize {
+        self.rows.len().saturating_sub(1)
+    }
+
+    fn drive<C: Consumer<Self::Item>>(self, consumer: C) -> C::Result {
+        bridge(self, consumer)
+    }
+
+    fn with_producer<CB: ProducerCallback<Self::Item>>(self, callback: CB) -> CB::Output {
+        callback.callback(CSRProducer {
+            rows: self.rows,
+            columns: self.columns,
+            weights: self.weights,
+        })
+    }
+}
+
+/// Producer used by rayon to drive parallel splits of a CSRParIterMut.
+struct CSRProducer<'a> {
+    rows: &'a [NodeID],
+    columns: &'a mut [NodeID],
+    weights: &'a mut [f32],
+}
+
+impl<'a> Producer for CSRProducer<'a> {
+    type Item = (&'a mut [NodeID], &'a mut [f32]);
+    type IntoIter = CSRSeqIter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        CSRSeqIter {
+            rows: self.rows,
+            cols: self.columns,
+            wgts: self.weights,
+        }
+    }
+
+    fn split_at(self, mid: usize) -> (Self, Self) {
+        // Invariant: columns.len() == weights.len() == rows.last() - rows.first().
+        // After splits rows[0] may be non-zero, so subtract base to get the local boundary.
+        let base = self.rows[0];
+        let boundary = self.rows[mid] - base;
+        let (cols_l, cols_r) = self.columns.split_at_mut(boundary);
+        let (wgts_l, wgts_r) = self.weights.split_at_mut(boundary);
+        let rows_l = &self.rows[..=mid];
+        let rows_r = &self.rows[mid..];
+        (
+            CSRProducer { rows: rows_l, columns: cols_l, weights: wgts_l },
+            CSRProducer { rows: rows_r, columns: cols_r, weights: wgts_r },
+        )
+    }
+}
+
+/// Sequential leaf iterator; peels one node off the front of its buffers per call.
+struct CSRSeqIter<'a> {
+    rows: &'a [NodeID],
+    cols: &'a mut [NodeID],
+    wgts: &'a mut [f32],
+}
+
+impl<'a> Iterator for CSRSeqIter<'a> {
+    type Item = (&'a mut [NodeID], &'a mut [f32]);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.rows.len() < 2 {
+            return None;
+        }
+        // Move the full-length slice out of self so we can split it; the tail
+        // goes back in.  mem::take works here since &mut [T] has a Default impl.
+        let len = self.rows[1] - self.rows[0];
+        let cols = std::mem::take(&mut self.cols);
+        let wgts = std::mem::take(&mut self.wgts);
+        let (ch, ct) = cols.split_at_mut(len);
+        let (wh, wt) = wgts.split_at_mut(len);
+        self.cols = ct;
+        self.wgts = wt;
+        self.rows = &self.rows[1..];
+        Some((ch, wh))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let n = self.rows.len().saturating_sub(1);
+        (n, Some(n))
+    }
+}
+
+impl<'a> DoubleEndedIterator for CSRSeqIter<'a> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.rows.len() < 2 {
+            return None;
+        }
+        // Peel the tail node by splitting off the last `last_len` elements.
+        let n = self.rows.len() - 1;
+        let last_len = self.rows[n] - self.rows[n - 1];
+        let keep = self.cols.len() - last_len;
+        let cols = std::mem::take(&mut self.cols);
+        let wgts = std::mem::take(&mut self.wgts);
+        let (ch, ct) = cols.split_at_mut(keep);
+        let (wh, wt) = wgts.split_at_mut(keep);
+        self.cols = ch;
+        self.wgts = wh;
+        self.rows = &self.rows[..n];
+        Some((ct, wt))
+    }
+}
+
+impl<'a> ExactSizeIterator for CSRSeqIter<'a> {
+    fn len(&self) -> usize {
+        self.rows.len().saturating_sub(1)
+    }
+}
+
 /// Normalizes sum of weights for a node to 1
 pub struct NormalizedCSR(CSR);
 
@@ -181,6 +340,11 @@ impl NormalizedCSR {
             }
         }
         NormalizedCSR(csr)
+    }
+
+    /// Parallel mutable access to each node's edge and weight slices.
+    pub fn par_iter_mut(&mut self) -> CSRParIterMut<'_> {
+        self.0.par_iter_mut()
     }
 }
 
@@ -217,6 +381,12 @@ impl ModifiableGraph for NormalizedCSR {
     /// Get edges and corresponding weights
     fn modify_edges(&mut self, idx: NodeID) -> (&mut [NodeID], &mut [f32]) {
         self.0.modify_edges(idx)
+    }
+}
+
+impl ParallelModifiableGraph for NormalizedCSR {
+    fn par_iter_mut(&mut self) -> CSRParIterMut<'_> {
+        self.0.par_iter_mut()
     }
 }
 
@@ -269,6 +439,12 @@ impl CumCSR {
         }
 
         Ok(CumCSR(graph))
+    }
+
+    /// Parallel mutable access to each node's edge and weight slices.  Note that arbitrary
+    /// mutation can break the CDF invariant - callers are responsible for restoring it.
+    pub fn par_iter_mut(&mut self) -> CSRParIterMut<'_> {
+        self.0.par_iter_mut()
     }
 }
 
@@ -345,7 +521,7 @@ impl Graph for CumCSR {
 }
 
 impl ModifiableGraph for CumCSR {
-    
+
     /// Get edges and corresponding weights
     fn modify_edges(&mut self, idx: NodeID) -> (&mut [NodeID], &mut [f32]) {
         self.0.modify_edges(idx)
@@ -353,16 +529,22 @@ impl ModifiableGraph for CumCSR {
 
 }
 
+impl ParallelModifiableGraph for CumCSR {
+    fn par_iter_mut(&mut self) -> CSRParIterMut<'_> {
+        self.0.par_iter_mut()
+    }
+}
+
 impl CDFGraph for CumCSR {}
 
 /// This is a graph which allows us to swap in a new set of edge weights without having to copy the
 /// entire graph.  We use it in cases where policies update edge transition probabilities.
-pub struct OptCDFGraph<'a,G> {
+pub struct OptCDFGraph<'a, G> {
     graph: &'a G,
     weights: Vec<f32>
 }
 
-impl <'a,G:Graph> OptCDFGraph<'a,G> {
+impl <'a, G:Graph> OptCDFGraph<'a,G> {
     pub fn new(graph: &'a G, weights: Vec<f32>) -> Self {
         let mut s = OptCDFGraph { graph, weights };
         s.convert_edges();
@@ -384,7 +566,7 @@ impl <'a,G:Graph> OptCDFGraph<'a,G> {
 
 }
 
-impl <'a,G:CDFGraph> OptCDFGraph<'a,G> {
+impl <'a, G:CDFGraph> OptCDFGraph<'a, G> {
     pub fn clone_from_cdf(graph: &'a G) -> Self {
         let mut weights = vec![0f32; graph.edges()];
         for node_id in 0..graph.len() {
@@ -398,7 +580,7 @@ impl <'a,G:CDFGraph> OptCDFGraph<'a,G> {
 
 }
 
-impl <'a,G:Graph> Graph for OptCDFGraph<'a,G> {
+impl <'a, G:Graph> Graph for OptCDFGraph<'a,G> {
     /// Get number of nodes in graph
     fn len(&self) -> usize {
         self.graph.len()
@@ -505,7 +687,7 @@ mod csr_tests {
     fn construct_csr() {
         let edges = build_edges();
 
-        let csr = CSR::construct_from_edges(edges);
+        let csr = CSR::construct_from_edges(edges, true);
         assert_eq!(csr.rows, vec![0, 1, 4, 5]);
         assert_eq!(csr.columns, vec![1, 1, 2, 0, 0]);
         assert_eq!(csr.weights, vec![1., 3., 2., 10., 2.5]);
@@ -515,7 +697,7 @@ mod csr_tests {
     fn test_graph() {
         let edges = build_edges();
 
-        let mut csr = CSR::construct_from_edges(edges);
+        let mut csr = CSR::construct_from_edges(edges, true);
         assert_eq!(csr.len(), 3);
         assert_eq!(csr.degree(0), 1);
         assert_eq!(csr.degree(1), 3);
@@ -535,7 +717,7 @@ mod csr_tests {
     fn construct_mk() {
         let edges = build_edges();
 
-        let csr = CSR::construct_from_edges(edges);
+        let csr = CSR::construct_from_edges(edges, true);
         let mk = NormalizedCSR::convert(csr);
 
         assert_eq!(mk.get_edges(0), (vec![1].as_slice(), vec![1.].as_slice()));
@@ -548,7 +730,7 @@ mod csr_tests {
     fn construct_cdf() {
         let edges = build_edges();
 
-        let csr = CSR::construct_from_edges(edges);
+        let csr = CSR::construct_from_edges(edges, true);
         let ccsr = CumCSR::convert(csr);
 
         assert_eq!(ccsr.0.rows, vec![0, 1, 4, 5]);
@@ -561,7 +743,7 @@ mod csr_tests {
     fn construct_cdf_to_p() {
         let edges = build_edges();
 
-        let csr = CSR::construct_from_edges(edges);
+        let csr = CSR::construct_from_edges(edges, true);
         let ccsr = CumCSR::convert(csr);
 
         let weights = ccsr.get_edges(1).1;
@@ -576,13 +758,141 @@ mod csr_tests {
     fn transpose_matrix() {
         let edges = build_edges();
 
-        let csr = CSR::construct_from_edges(edges);
+        let csr = CSR::construct_from_edges(edges, true);
         let ccsr = CumCSR::convert(csr);
 
-        let t_ccsr = ccsr.transpose();
+        let _t_ccsr = ccsr.transpose();
 
     }
 
+    /// Sanity check that a plain `.for_each` reaches every weight.  After dedup the
+    /// edges are sorted by (from, to), so node 1's weights are [10, 3, 2] -> doubled
+    /// to [20, 6, 4].
+    #[test]
+    fn test_par_iter_mut_for_each_doubles_weights() {
+        let edges = build_edges();
+        let mut csr = CSR::construct_from_edges(edges, true);
+        csr.par_iter_mut().for_each(|(_e, w)| {
+            w.iter_mut().for_each(|x| *x *= 2.0);
+        });
+        assert_eq!(csr.get_edges(0), ([1usize].as_slice(), [2.0f32].as_slice()));
+        assert_eq!(csr.get_edges(1).1, [20.0, 6.0, 4.0].as_slice());
+        assert_eq!(csr.get_edges(2), ([0usize].as_slice(), [5.0f32].as_slice()));
+    }
 
+    /// Verify `.enumerate()` hands each worker the right node index.
+    #[test]
+    fn test_par_iter_mut_enumerate_writes_node_id() {
+        let edges = build_edges();
+        let mut csr = CSR::construct_from_edges(edges, true);
+        csr.par_iter_mut().enumerate().for_each(|(i, (_e, w))| {
+            w.iter_mut().for_each(|x| *x = i as f32);
+        });
+        for i in 0..csr.len() {
+            for &x in csr.get_edges(i).1 {
+                assert_eq!(x, i as f32);
+            }
+        }
+    }
 
+    /// A zero-degree node should yield an empty slice pair without tripping the split logic.
+    #[test]
+    fn test_par_iter_mut_zero_degree_node() {
+        // node 1 has degree 0
+        let edges = vec![(0usize, 2usize, 1.0f32), (2, 0, 2.0)];
+        let mut csr = CSR::construct_from_edges(edges, true);
+        assert_eq!(csr.degree(1), 0);
+
+        csr.par_iter_mut().for_each(|(_e, w)| {
+            if !w.is_empty() {
+                w.iter_mut().for_each(|x| *x += 100.0);
+            }
+        });
+
+        assert_eq!(csr.get_edges(0).1, &[101.0]);
+        assert_eq!(csr.get_edges(2).1, &[102.0]);
+        assert_eq!(csr.degree(1), 0);
+    }
+
+    /// Guard against double-visits or skipped nodes in the split tree.  Atomic counters
+    /// let the workers tally hits in parallel without racing the assertion.
+    #[test]
+    fn test_par_iter_mut_visits_each_node_once() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        let edges = build_edges();
+        let mut csr = CSR::construct_from_edges(edges, true);
+        let n = csr.len();
+        let counts: Vec<AtomicUsize> = (0..n).map(|_| AtomicUsize::new(0)).collect();
+
+        csr.par_iter_mut().enumerate().for_each(|(i, (_e, w))| {
+            counts[i].fetch_add(1, Ordering::Relaxed);
+            w.iter_mut().for_each(|x| *x = i as f32);
+        });
+
+        for (i, c) in counts.iter().enumerate() {
+            assert_eq!(c.load(Ordering::Relaxed), 1, "node {i} hit count");
+        }
+        for i in 0..n {
+            for &x in csr.get_edges(i).1 {
+                assert_eq!(x, i as f32);
+            }
+        }
+    }
+
+    /// NormalizedCSR delegates to the inner CSR; confirm mutation is visible through the wrapper.
+    #[test]
+    fn test_normalized_csr_par_iter_mut_delegates() {
+        let edges = build_edges();
+        let mut norm = NormalizedCSR::convert(CSR::construct_from_edges(edges, true));
+
+        norm.par_iter_mut().for_each(|(_e, w)| {
+            w.iter_mut().for_each(|x| *x = 0.0);
+        });
+
+        for i in 0..norm.len() {
+            for &x in norm.get_edges(i).1 {
+                assert_eq!(x, 0.0);
+            }
+        }
+    }
+
+    /// CumCSR delegates the same way; we ignore the CDF invariant here since we're testing plumbing.
+    #[test]
+    fn test_cum_csr_par_iter_mut_delegates() {
+        let edges = build_edges();
+        let mut cum = CumCSR::convert(CSR::construct_from_edges(edges, true));
+
+        cum.par_iter_mut().enumerate().for_each(|(i, (_e, w))| {
+            w.iter_mut().for_each(|x| *x = i as f32);
+        });
+
+        for i in 0..cum.len() {
+            for &x in cum.get_edges(i).1 {
+                assert_eq!(x, i as f32);
+            }
+        }
+    }
+
+    /// Exercise the Producer::split_at path under real rayon work-stealing with enough nodes
+    /// that the split tree has real depth.  3 edges/node keeps the CSR small but non-trivial.
+    #[test]
+    fn test_par_iter_mut_scale_1000_nodes() {
+        let mut edges: Vec<(usize, usize, f32)> = Vec::with_capacity(3_000);
+        for i in 0..1000usize {
+            edges.push((i, (i + 1) % 1000, 1.0));
+            edges.push((i, (i + 7) % 1000, 1.0));
+            edges.push((i, (i + 31) % 1000, 1.0));
+        }
+
+        let mut csr = CSR::construct_from_edges(edges, true);
+        csr.par_iter_mut().enumerate().for_each(|(i, (_e, w))| {
+            w.iter_mut().for_each(|x| *x = i as f32);
+        });
+
+        for i in 0..csr.len() {
+            for &x in csr.get_edges(i).1 {
+                assert_eq!(x, i as f32);
+            }
+        }
+    }
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -82,7 +82,7 @@ impl CSR {
         }).max().unwrap_or(0);
 
         // Figure out how many out edges per node
-        let mut rows = vec![0; max_node+2];
+        let mut rows = vec![0; max_node + 2];
         edges.iter().for_each(|(from_node, _to_node, _w)| {
             rows[*from_node + 1] += 1;
         });
@@ -120,12 +120,14 @@ impl CSR {
     fn deduplicate_edges(
         edges: &mut Vec<(NodeID, NodeID, f32)>
     ) -> () {
+
         edges.par_sort_by_key(|(f_n, t_n, _)| (*f_n, *t_n));
+
         let mut cur_record = 0;
-        let mut idx = 1;
-        while idx < edges.len() {
+        for idx in 1..edges.len() {
             let (f_n, t_n, w) = edges[idx];
             let c_r = edges[cur_record];
+            
             // Same edge, add the weights.
             if f_n == c_r.0 && t_n == c_r.1 {
                 (&mut edges[cur_record]).2 += w;
@@ -134,7 +136,6 @@ impl CSR {
                 cur_record += 1;
                 edges[cur_record] = edges[idx];
             }
-            idx += 1;
         }
         edges.truncate(cur_record + 1);
 
@@ -398,12 +399,23 @@ impl NormalizedGraph for NormalizedCSR {}
 pub struct CumCSR(CSR);
 
 impl CumCSR {
+    /// Cheap placeholder: a zero-node, zero-edge CumCSR.  Intended as a temporary
+    /// value for `std::mem::replace`-based swaps so callers can take unique
+    /// ownership of the real inner CSR without cloning its rows/columns/weights.
+    pub fn empty() -> Self {
+        CumCSR(CSR {
+            rows: vec![0],
+            columns: Vec::new(),
+            weights: Vec::new(),
+        })
+    }
+
     /// Converts a Compressed Sparse Row Format into a CDF version of weights
     pub fn convert(mut csr: CSR) -> Self {
         for start_stop in csr.rows.windows(2) {
             let (start, stop) = (start_stop[0], start_stop[1]);
             if start < stop {
-                convert_edges_to_cdf(&mut csr.weights[start..stop]);
+                convert_edges_to_cdf(&mut csr.weights[start..stop], None);
             }
         }
         CumCSR(csr)
@@ -559,7 +571,7 @@ impl <'a, G:Graph> OptCDFGraph<'a,G> {
         for idx in 0..self.len() {
             let (start, stop) = self.get_edge_range(idx);
             if start < stop {
-                convert_edges_to_cdf(&mut self.weights[start..stop]);
+                convert_edges_to_cdf(&mut self.weights[start..stop], None);
             }
         }
     }
@@ -649,8 +661,11 @@ impl <'a> Iterator for CDFtoP<'a> {
 }
 
 /// Converts a set of weights to CDF
-pub fn convert_edges_to_cdf(weights: &mut [f32]) {
-    let mut denom = weights.iter().sum::<f32>();
+pub fn convert_edges_to_cdf(weights: &mut [f32], sum: Option<f32>) {
+
+    // Figure out denominator.
+    let mut denom = sum.unwrap_or_else(|| weights.iter().sum::<f32>());
+
     if denom == 0f32 {
         // If we have no weights, set all weights to uniform.
         weights.iter_mut().for_each(|w| {
@@ -662,7 +677,7 @@ pub fn convert_edges_to_cdf(weights: &mut [f32]) {
     let mut acc = 0.;
     weights.iter_mut().for_each(|w| {
         acc += *w;
-        *w = acc / denom;
+        *w = (acc / denom).min(1.0);
     });
 
     // Accumulation error can result in it not equaling 1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ use std::collections::HashSet;
 use rayon::prelude::*;
 use float_ord::FloatOrd;
 use pyo3::prelude::*;
-use pyo3::exceptions::{PyValueError,PyIOError,PyKeyError,PyIndexError,PyTypeError};
+use pyo3::exceptions::{PyValueError,PyIOError,PyKeyError,PyIndexError,PyTypeError,PyRuntimeError};
 use itertools::Itertools;
 use rand::prelude::*;
 use rand_xorshift::XorShiftRng;
@@ -77,6 +77,7 @@ use crate::algos::instantembedding::{InstantEmbeddings as IE,Estimator};
 use crate::algos::lsr::{LSR as ALSR};
 use crate::algos::pprembed::PPREmbed;
 use crate::algos::pprrank::{PprRank, Loss as PprLoss};
+use crate::algos::policy_evaluation::{PolicyEvaluation as PEA};
 use crate::algos::reweighter::{Reweighter};
 use crate::algos::rwr::{RWR,ppr_estimate,rollout};
 use crate::algos::smci::SupervisedMCIteration;
@@ -292,6 +293,21 @@ impl Distance {
 pub struct Graph {
     graph: Arc<CumCSR>,
     vocab: Arc<Vocab>
+}
+
+impl Graph {
+    /// Swap the inner `Arc<CumCSR>` out, replacing it with an empty placeholder.
+    /// The caller owns the returned Arc; the Graph is left in a valid-but-empty
+    /// state that must be repaired via `put_inner` before returning control.
+    /// Pairs with `put_inner` to support in-place optimizers that need unique
+    /// ownership of the CSR without bumping the refcount.
+    pub(crate) fn take_inner(&mut self) -> Arc<CumCSR> {
+        std::mem::replace(&mut self.graph, Arc::new(CumCSR::empty()))
+    }
+
+    pub(crate) fn put_inner(&mut self, inner: Arc<CumCSR>) {
+        self.graph = inner;
+    }
 }
 
 #[pymethods]
@@ -3621,24 +3637,28 @@ impl Smci {
 /// edges via softmax to bias trajectories toward higher-value states.
 #[pyclass]
 struct PolicyEvaluation {
-    graph: Arc<CumCSR>,
     vocab: Arc<Vocab>,
     gamma: f32,
     iterations: usize,
     eps: f32,
     temperature: f32,
     rewards: Vec<f32>,
-    indicator: Option<bool>,
 }
 
 #[pymethods]
 impl PolicyEvaluation {
-    ///    Creates a PolicyEvaluation instance for a given graph.
+    ///    Creates a PolicyEvaluation instance seeded from a graph's vocabulary.
+    ///
+    ///    The graph itself is NOT stored on the returned object.  Pass it back
+    ///    to `optimize(graph)` when you're ready to run.  This avoids holding
+    ///    an extra reference to the graph, which would force a full copy of
+    ///    its edges inside `optimize`.
     ///
     ///    Parameters
     ///    ----------
     ///    graph : Graph
-    ///        Graph to run policy evaluation on.
+    ///        Graph whose vocabulary and size seed this PolicyEvaluation.  The
+    ///        same graph should be passed to `optimize` later.
     ///
     ///    gamma : Float - Optional
     ///        Discount factor ~ [0, 1).  Higher values make the agent plan further
@@ -3666,18 +3686,15 @@ impl PolicyEvaluation {
         iterations: Option<usize>,
         eps: Option<f32>,
         temperature: Option<f32>,
-        indicator: Option<bool>,
     ) -> Self {
         let n = graph.graph.len();
         PolicyEvaluation {
-            graph: graph.graph.clone(),
             vocab: graph.vocab.clone(),
             gamma: gamma.unwrap_or(0.99),
             iterations: iterations.unwrap_or(100),
             eps: eps.unwrap_or(1e-6),
             temperature: temperature.unwrap_or(1.0),
             rewards: vec![0f32; n],
-            indicator: indicator,
         }
     }
 
@@ -3743,28 +3760,82 @@ impl PolicyEvaluation {
         Ok(())
     }
 
-    ///    Runs policy evaluation and mutates the graph weights in place.
+    ///    Runs policy evaluation and rewrites the passed graph's edge weights
+    ///    in place.
+    ///
+    ///    Parameters
+    ///    ----------
+    ///    graph : Graph
+    ///        Graph to optimize.  Must have been built from the same vocabulary
+    ///        as this PolicyEvaluation.  Edge weights are mutated in place;
+    ///        no new Graph is returned.
+    ///
+    ///    no_copy : Bool - Optional
+    ///        When True (default), raises an exception instead of silently
+    ///        copying the graph if it has other live references.  This is the
+    ///        whole point of the refactor — accidental allocations should be
+    ///        loud.  Pass False to opt into a full copy when that's what you
+    ///        want.
+    ///
+    ///    indicator : Bool - Optional
+    ///        Show a progress bar while iterating.  Defaults to True.
     ///
     ///    Returns
     ///    -------
-    ///    Graph
-    ///        Graph whose edge weights now reflect the optimal policy.
-    pub fn optimize(&mut self) -> PyResult<Graph> {
-        let vi = crate::algos::policy_evaluation::PolicyEvaluation::new(
+    ///    () - Can throw exception
+    pub fn optimize(
+        &self,
+        graph: &mut Graph,
+        no_copy: Option<bool>,
+        indicator: Option<bool>,
+    ) -> PyResult<()> {
+        // Identity check: PE's vocab must be the vocab the graph was built with,
+        // otherwise `rewards[node_id]` is meaningless against this graph.
+        if !Arc::ptr_eq(&self.vocab, &graph.vocab) {
+            return Err(PyValueError::new_err(
+                "PolicyEvaluation was built from a different graph's vocabulary; \
+                 construct a new PolicyEvaluation from this graph before optimizing."
+            ));
+        }
+
+        let no_copy = no_copy.unwrap_or(true);
+
+        // Swap out the inner Arc<CumCSR>; the Graph is temporarily backed by an
+        // empty CSR.  Taking exclusive ownership this way lets us mutate the
+        // CSR without forcing a clone.
+        let taken = graph.take_inner();
+
+        let mut owned: CumCSR = match Arc::try_unwrap(taken) {
+            Ok(csr) => csr,
+            Err(shared) => {
+                if no_copy {
+                    graph.put_inner(shared);
+                    return Err(PyRuntimeError::new_err(
+                        "Cannot optimize in place: this graph has other live \
+                         references, so running the optimizer would require \
+                         making a full copy of it.  Release the other references \
+                         (for example, drop any other Python variables pointing \
+                         at the same graph) or pass no_copy=False to allow the \
+                         copy."
+                    ));
+                }
+                (*shared).clone()
+            }
+        };
+
+        let vi = PEA::new(
             self.gamma,
             self.iterations,
             self.eps,
             self.temperature,
-            self.indicator.unwrap_or(true),
+            indicator.unwrap_or(true),
         );
-        let values = vi.compute(self.graph.as_ref(), &self.rewards);
-        let graph = Arc::make_mut(&mut self.graph);
-        vi.update_policy_weights_in_place(graph, &values);
 
-        Ok(Graph {
-            graph: self.graph.clone(),
-            vocab: self.vocab.clone(),
-        })
+        let values = vi.compute(&owned, &self.rewards);
+        vi.update_policy_weights_in_place(&mut owned, &values);
+
+        graph.put_inner(Arc::new(owned));
+        Ok(())
     }
 }
 

--- a/test_no_copy.py
+++ b/test_no_copy.py
@@ -1,0 +1,115 @@
+"""
+Validates PolicyEvaluation's new in-place optimize(graph, no_copy=...) contract:
+
+  1. Happy path: no other references to the graph -> default (no_copy=True) succeeds.
+  2. Shared inner Arc (via Smci holding a clone) -> default no_copy=True raises
+     RuntimeError with a Python-flavored message, and the graph is left intact.
+  3. Same sharing, but no_copy=False -> falls back to a clone and succeeds.
+"""
+import cloverleaf
+
+
+def build_graph():
+    # Use Undirected so every node has at least one outbound edge; the
+    # policy-evaluation CDF update path panics on dead-end nodes (pre-existing
+    # bug in src/graph.rs:684, not part of this refactor).
+    gb = cloverleaf.GraphBuilder()
+    gb.add_edge(("user", "alice"), ("prod", "widget"), 3.0, cloverleaf.EdgeType.Undirected)
+    gb.add_edge(("user", "alice"), ("prod", "gadget"), 1.0, cloverleaf.EdgeType.Undirected)
+    gb.add_edge(("user", "bob"), ("prod", "gadget"), 5.0, cloverleaf.EdgeType.Undirected)
+    gb.add_edge(("user", "bob"), ("prod", "doohickey"), 2.0, cloverleaf.EdgeType.Undirected)
+    return gb.build_graph()
+
+
+def make_pe(graph):
+    pe = cloverleaf.PolicyEvaluation(
+        graph, gamma=0.9, iterations=50, eps=1e-6, temperature=0.5
+    )
+    pe.set_reward(("prod", "widget"), 10.0)
+    pe.set_reward(("prod", "gadget"), 5.0)
+    pe.set_reward(("prod", "doohickey"), 2.0)
+    return pe
+
+
+def snapshot(graph):
+    snap = {}
+    for nt, nn in graph.vocab():
+        nodes, weights = graph.get_edges((nt, nn), normalized=True)
+        if nodes:
+            snap[(nt, nn)] = list(weights)
+    return snap
+
+
+def weights_equal(a, b):
+    if set(a) != set(b):
+        return False
+    for k in a:
+        if len(a[k]) != len(b[k]):
+            return False
+        for wa, wb in zip(a[k], b[k]):
+            if abs(wa - wb) > 1e-6:
+                return False
+    return True
+
+
+def test_happy_path():
+    graph = build_graph()
+    pe = make_pe(graph)
+    before = snapshot(graph)
+    pe.optimize(graph, indicator=False)  # no_copy defaults to True
+    after = snapshot(graph)
+    assert not weights_equal(before, after), "graph weights should have changed"
+    print("PASS: no_copy=True default succeeds when graph has no other references")
+
+
+def test_shared_arc_raises_by_default():
+    graph = build_graph()
+    pe = make_pe(graph)
+    # Smci's constructor clones graph.graph (Arc<CumCSR>) into its struct.
+    # That bumps the inner CSR's refcount to 2 -> optimize must refuse.
+    _smci = cloverleaf.Smci(graph)
+    before = snapshot(graph)
+    try:
+        pe.optimize(graph, indicator=False)
+    except RuntimeError as e:
+        msg = str(e)
+        assert "other live references" in msg, f"unexpected message: {msg}"
+        assert "no_copy=False" in msg, f"message must mention the escape hatch: {msg}"
+        after = snapshot(graph)
+        assert weights_equal(before, after), "graph should be untouched after the error"
+        print("PASS: no_copy=True default raises RuntimeError on shared graph")
+        print(f"       message: {msg!r}")
+        return
+    raise AssertionError("optimize should have raised but did not")
+
+
+def test_shared_arc_opt_in_copy():
+    graph = build_graph()
+    pe = make_pe(graph)
+    _smci = cloverleaf.Smci(graph)
+    before = snapshot(graph)
+    pe.optimize(graph, no_copy=False, indicator=False)
+    after = snapshot(graph)
+    assert not weights_equal(before, after), "graph weights should have changed"
+    print("PASS: no_copy=False falls back to clone and succeeds on shared graph")
+
+
+def test_vocab_mismatch():
+    g1 = build_graph()
+    g2 = build_graph()  # independently built => independent vocab Arc
+    pe = make_pe(g1)
+    try:
+        pe.optimize(g2, indicator=False)
+    except ValueError as e:
+        assert "different graph" in str(e).lower() or "vocabulary" in str(e).lower(), str(e)
+        print("PASS: vocab mismatch raises ValueError")
+        return
+    raise AssertionError("optimize on different-vocab graph should have raised")
+
+
+if __name__ == "__main__":
+    test_happy_path()
+    test_shared_arc_raises_by_default()
+    test_shared_arc_opt_in_copy()
+    test_vocab_mismatch()
+    print("\nAll no_copy contract tests passed.")

--- a/tests/par_iter_mut.rs
+++ b/tests/par_iter_mut.rs
@@ -1,0 +1,132 @@
+//! Integration tests for the parallel mutation API on CSR-backed graph types.
+
+use cloverleaf::graph::{CSR, CumCSR, Graph, NormalizedCSR};
+use rayon::iter::{IndexedParallelIterator, ParallelIterator};
+
+fn build_edges() -> Vec<(usize, usize, f32)> {
+    vec![
+        (0, 1, 1.),
+        (1, 1, 3.),
+        (1, 2, 2.),
+        (2, 0, 2.5),
+        (1, 0, 10.),
+    ]
+}
+
+/// Sanity check that a plain `.for_each` reaches every weight.  After dedup the
+/// edges are sorted by (from, to), so node 1's weights are [10, 3, 2] -> doubled
+/// to [20, 6, 4].
+#[test]
+fn par_iter_mut_for_each_doubles_weights() {
+    let mut csr = CSR::construct_from_edges(build_edges(), true);
+    csr.par_iter_mut().for_each(|(_e, w)| {
+        w.iter_mut().for_each(|x| *x *= 2.0);
+    });
+    assert_eq!(csr.get_edges(0), ([1usize].as_slice(), [2.0f32].as_slice()));
+    assert_eq!(csr.get_edges(1).1, [20.0, 6.0, 4.0].as_slice());
+    assert_eq!(csr.get_edges(2), ([0usize].as_slice(), [5.0f32].as_slice()));
+}
+
+/// Verify `.enumerate()` hands each worker the right node index.
+#[test]
+fn par_iter_mut_enumerate_writes_node_id() {
+    let mut csr = CSR::construct_from_edges(build_edges(), true);
+    csr.par_iter_mut().enumerate().for_each(|(i, (_e, w))| {
+        w.iter_mut().for_each(|x| *x = i as f32);
+    });
+    for i in 0..csr.len() {
+        for &x in csr.get_edges(i).1 {
+            assert_eq!(x, i as f32);
+        }
+    }
+}
+
+/// A zero-degree node should yield an empty slice pair without tripping the split logic.
+#[test]
+fn par_iter_mut_zero_degree_node() {
+    // node 1 has degree 0
+    let edges = vec![(0usize, 2usize, 1.0f32), (2, 0, 2.0)];
+    let mut csr = CSR::construct_from_edges(edges, true);
+    assert_eq!(csr.degree(1), 0);
+    csr.par_iter_mut().for_each(|(_e, w)| {
+        if !w.is_empty() {
+            w.iter_mut().for_each(|x| *x += 100.0);
+        }
+    });
+    assert_eq!(csr.get_edges(0).1, &[101.0]);
+    assert_eq!(csr.get_edges(2).1, &[102.0]);
+    assert_eq!(csr.degree(1), 0);
+}
+
+/// Guard against double-visits or skipped nodes in the split tree.  Atomic counters
+/// let the workers tally hits in parallel without racing the assertion.
+#[test]
+fn par_iter_mut_visits_each_node_once() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    let mut csr = CSR::construct_from_edges(build_edges(), true);
+    let n = csr.len();
+    let counts: Vec<AtomicUsize> = (0..n).map(|_| AtomicUsize::new(0)).collect();
+
+    csr.par_iter_mut().enumerate().for_each(|(i, (_e, w))| {
+        counts[i].fetch_add(1, Ordering::Relaxed);
+        w.iter_mut().for_each(|x| *x = i as f32);
+    });
+
+    for (i, c) in counts.iter().enumerate() {
+        assert_eq!(c.load(Ordering::Relaxed), 1, "node {i} hit count");
+    }
+    for i in 0..n {
+        for &x in csr.get_edges(i).1 {
+            assert_eq!(x, i as f32);
+        }
+    }
+}
+
+/// NormalizedCSR delegates to the inner CSR; confirm mutation is visible through the wrapper.
+#[test]
+fn normalized_csr_par_iter_mut_delegates() {
+    let mut norm = NormalizedCSR::convert(CSR::construct_from_edges(build_edges(), true));
+    norm.par_iter_mut().for_each(|(_e, w)| {
+        w.iter_mut().for_each(|x| *x = 0.0);
+    });
+    for i in 0..norm.len() {
+        for &x in norm.get_edges(i).1 {
+            assert_eq!(x, 0.0);
+        }
+    }
+}
+
+/// CumCSR delegates the same way; we ignore the CDF invariant here since we're testing plumbing.
+#[test]
+fn cum_csr_par_iter_mut_delegates() {
+    let mut cum = CumCSR::convert(CSR::construct_from_edges(build_edges(), true));
+    cum.par_iter_mut().enumerate().for_each(|(i, (_e, w))| {
+        w.iter_mut().for_each(|x| *x = i as f32);
+    });
+    for i in 0..cum.len() {
+        for &x in cum.get_edges(i).1 {
+            assert_eq!(x, i as f32);
+        }
+    }
+}
+
+/// Exercise the Producer::split_at path under real rayon work-stealing with enough nodes
+/// that the split tree has real depth.  3 edges/node keeps the CSR small but non-trivial.
+#[test]
+fn par_iter_mut_scale_1000_nodes() {
+    let mut edges: Vec<(usize, usize, f32)> = Vec::with_capacity(3_000);
+    for i in 0..1000usize {
+        edges.push((i, (i + 1) % 1000, 1.0));
+        edges.push((i, (i + 7) % 1000, 1.0));
+        edges.push((i, (i + 31) % 1000, 1.0));
+    }
+    let mut csr = CSR::construct_from_edges(edges, true);
+    csr.par_iter_mut().enumerate().for_each(|(i, (_e, w))| {
+        w.iter_mut().for_each(|x| *x = i as f32);
+    });
+    for i in 0..csr.len() {
+        for &x in csr.get_edges(i).1 {
+            assert_eq!(x, i as f32);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`PolicyEvaluation` used to keep its own `Arc<CumCSR>` cloned from the
`Graph` constructor argument.  Because the original `Graph` stayed
alive in Python, the Arc refcount was always ≥ 2 by the time
`optimize()` ran, and the `Arc::make_mut` on that path silently
performed a full deep clone of the CSR on every call — hundreds of
megabytes for a large graph, every time.

This change:

- Drops the owned `Arc<CumCSR>` from the struct; the graph is now
  passed to `optimize(graph, ...)` at call time, matching the
  `FeatureSet` convention.
- Swaps the inner `Arc<CumCSR>` out of the `Graph` via
  `std::mem::replace` (with a new `CumCSR::empty()` placeholder),
  `Arc::try_unwrap`s it, mutates in place, and puts it back.  Zero
  copies in the happy path.
- Adds a `no_copy` flag to `optimize` — default `True` — that raises a
  Python-friendly `RuntimeError` if the graph has other live references
  that would force a clone.  Callers who actually want a copy opt in
  with `no_copy=False`.
- Moves `indicator` from the constructor to `optimize()` since it is a
  per-run UI choice, not a property of the evaluation configuration.
- Switches `update_policy_weights_in_place` from a serial
  `modify_edges` loop to `par_iter_mut`, and folds the local
  `normalize_to_cdf` helper into `convert_edges_to_cdf` by giving the
  latter an optional pre-computed sum argument.
- Adds `pub(crate) Graph::take_inner` / `put_inner` to encapsulate the
  swap dance for future in-place optimizers.

### Python API break

`pe.optimize()` no longer returns a `Graph`.  It mutates the passed
graph in place and returns `None`.  Callers that did
`new_g = pe.optimize()` become `pe.optimize(graph)`.  The `indicator`
kwarg moves from the constructor to `optimize()`.

## Test plan

- [x] `cargo check --lib` builds clean.
- [x] `maturin develop --release` builds the extension into the venv.
- [x] `python test_no_copy.py` validates all four contracts end-to-end:
  - no_copy=True default succeeds when the graph has no other references
  - no_copy=True raises RuntimeError when another holder shares the Arc (exercised by constructing an `Smci(graph)` that clones the Arc)
  - no_copy=False falls back to a clone and succeeds on a shared graph
  - vocab mismatch raises ValueError and leaves the graph untouched
- [ ] Manual run of `examples/policy_evaluation.py` once the downstream
  `convert_edges_to_cdf` panic on dead-end nodes (pre-existing,
  `src/graph.rs:684`) is addressed separately, or replace the example
  graph with one where every node has outbound edges.