### PR TITLE
Swap autograd engine for Candle

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 default = []
 accelerate = ["candle-core/accelerate"]
 metal = ["candle-core/metal"]
+cuda = ["candle-core/cuda"]
 
 [lib]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,7 @@ rayon = "1.5"
 float-ord = "0.2"
 atomic_float = "0.1"
 pyo3 = { version = "0.17.1", features = ["extension-module"] }
-simple_grad = {git = "https://github.com/Refefer/SimpleGrad"}
-#simple_grad = {path = "/home/andrew/Projects/simplegrad"}
+candle-core = "0.10.2"
 indicatif = "0.17.1"
 itertools = "0.10.5"
 ryu = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,11 @@ name = "cloverleaf"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+default = []
+accelerate = ["candle-core/accelerate"]
+metal = ["candle-core/metal"]
+
 [lib]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 name = "cloverleaf"

--- a/examples/autograd_embedding_propagation.py
+++ b/examples/autograd_embedding_propagation.py
@@ -1,0 +1,70 @@
+import math
+
+import cloverleaf
+
+
+def build_graph():
+    gb = cloverleaf.GraphBuilder()
+    for src, dst in [
+        (("doc", "a"), ("doc", "b")),
+        (("doc", "b"), ("doc", "c")),
+        (("doc", "c"), ("doc", "d")),
+        (("doc", "d"), ("doc", "a")),
+        (("doc", "a"), ("doc", "c")),
+    ]:
+        gb.add_edge(src, dst, 1.0, cloverleaf.EdgeType.Undirected)
+    return gb.build_graph()
+
+
+def build_features(graph):
+    features = cloverleaf.FeatureSet.new_from_graph(graph)
+    features.set_features(("doc", "a"), [("feat", "red"), ("feat", "round")])
+    features.set_features(("doc", "b"), [("feat", "red"), ("feat", "square")])
+    features.set_features(("doc", "c"), [("feat", "blue"), ("feat", "round")])
+    features.set_features(("doc", "d"), [("feat", "blue"), ("feat", "square")])
+    return features
+
+
+def run_propagation(graph, features, *, attention=False):
+    propagator = cloverleaf.EmbeddingPropagator(
+        alpha=0.01,
+        loss=cloverleaf.EPLoss.margin(1.0, 1),
+        batch_size=2,
+        dims=4,
+        passes=2,
+        seed=13,
+        max_nodes=None,
+        weighted_neighbor_sampling=False,
+        weighted_neighbor_averaging=False,
+        max_features=None,
+        loss_weighting=None,
+        valid_pct=0.0,
+        hard_negatives=0,
+        indicator=False,
+        attention=1 if attention else None,
+        attention_heads=1 if attention else None,
+        context_window=None,
+        noise=0.0,
+    )
+    return propagator.learn_features(graph, features, None)
+
+
+def assert_finite_embedding(embeddings, node):
+    vector = embeddings.get_embedding(node)
+    assert vector, f"missing embedding for {node}"
+    assert all(math.isfinite(value) for value in vector), vector
+    return vector
+
+
+if __name__ == "__main__":
+    graph = build_graph()
+
+    features = build_features(graph)
+    embeddings = run_propagation(graph, features, attention=False)
+    print("averaged dims:", embeddings.dims())
+    print("averaged feat:red:", assert_finite_embedding(embeddings, ("feat", "red")))
+
+    attention_features = build_features(graph)
+    attention_embeddings = run_propagation(graph, attention_features, attention=True)
+    print("attention dims:", attention_embeddings.dims())
+    print("attention feat:red:", assert_finite_embedding(attention_embeddings, ("feat", "red")))

--- a/src/algos/aggregator.rs
+++ b/src/algos/aggregator.rs
@@ -1,7 +1,7 @@
 //! Aggregators take models, feature embeddings, and a feature set and convert them into
 //! embeddings.  They are constructed adhoc so can be used in parallel as well as within the python
 //! interface
-use simple_grad::*;
+use crate::autograd::*;
 use rand::prelude::*;
 use rand_xorshift::XorShiftRng;
 
@@ -152,4 +152,3 @@ impl <'a> EmbeddingBuilder for AttentionAggregator<'a> {
         });
     }
 }
-

--- a/src/algos/emb_aligner.rs
+++ b/src/algos/emb_aligner.rs
@@ -1,4 +1,4 @@
-use simple_grad::*;
+use crate::autograd::*;
 
 pub fn align_embedding(
     embedding: &[f32],

--- a/src/algos/ep/attention.rs
+++ b/src/algos/ep/attention.rs
@@ -2,7 +2,7 @@
 //! attention methods.  Notably, we use averaged versus concat -> linear projection due to
 //! performance cost.  This has representational downsides but performs significantly faster and
 //! with no extra parmeters.
-use simple_grad::*;
+use crate::autograd::*;
 use float_ord::FloatOrd;
 use rand::prelude::*;
 
@@ -249,7 +249,7 @@ fn compute_random_attention_matrix(
 
 // Learn the softmax of the attention matrix.  Lots of effort in place to make this efficient,
 // within the limitations of dynamic allocations.  Might make sense to make a special attention
-// operator ala pytorch/tensorflow within simple_grad.
+// operator ala pytorch/tensorflow within the autograd backend.
 fn compute_attention_softmax(
     mut attention_matrix: AttentionMatrix,
     d_k: usize
@@ -282,7 +282,8 @@ fn compute_attention_softmax(
 // Simple softmax.
 pub fn softmax(numers: ANode, exact: bool) -> ANode {
     // Doesn't need to be part of the graph
-    let max_value = numers.value().iter()
+    let numer_values = numers.value();
+    let max_value = numer_values.iter()
         .max_by_key(|v| FloatOrd(**v))
         .expect("Shouldn't be non-zero!");
 

--- a/src/algos/ep/loss.rs
+++ b/src/algos/ep/loss.rs
@@ -1,7 +1,7 @@
 //! Defines the different losses for use within the Embedding Propagation framework.
 //! Admitedly, the EP framework isn't parameterized on loss, so technically choosing a loss other
 //! than Margin Loss is a different optimizer. 
-use simple_grad::*;
+use crate::autograd::*;
 use rand::prelude::*;
 use rand_distr::{Distribution,Uniform};
 
@@ -57,7 +57,7 @@ impl Loss {
         match self {
 
             Loss::MarginLoss(gamma, _) | Loss::PPR(gamma, _, _) => {
-                let d1 = gamma + euclidean_distance(&thv, &hv);
+                let d1 = *gamma + euclidean_distance(&thv, &hv);
                 let pos_losses = hus.iter()
                     .map(|hu| &d1 - euclidean_distance(&thv, hu))
                     .filter(|loss| loss.value()[0] > 0f32)
@@ -89,7 +89,7 @@ impl Loss {
                     .map(|hu| {
                         let hu_norm = il2norm(hu);
                         // Margin loss
-                        (gamma - (&reconstruction_dist - cosine(hv_norm.clone(), hu_norm))).maximum(0f32)
+                        (*gamma - (&reconstruction_dist - cosine(hv_norm.clone(), hu_norm))).maximum(0f32)
                     })
                     // Only collect losses which are not zero
                     .filter(|l| l.value()[0] > 0f32)
@@ -108,7 +108,7 @@ impl Loss {
                 let thv_norm = il2norm(&thv);
                 let hv_norm  = il2norm(&hv);
 
-                let pos_reconstruction = (pos_margin - cosine(thv_norm, hv_norm.clone())).maximum(0f32);
+                let pos_reconstruction = (*pos_margin - cosine(thv_norm, hv_norm.clone())).maximum(0f32);
                 let mut margins: Vec<_> = hus.iter().map(|hu| {
                         let hu_norm = il2norm(hu);
                         let cs = cosine(hv_norm.clone(), hu_norm);

--- a/src/algos/ep/mod.rs
+++ b/src/algos/ep/mod.rs
@@ -14,7 +14,7 @@ use std::collections::{HashMap as CHashMap};
 use rand::prelude::*;
 use rand_distr::StandardNormal;
 use rand_xorshift::XorShiftRng;
-use simple_grad::*;
+use crate::autograd::*;
 
 use crate::graph::{Graph as CGraph,NodeID};
 use crate::embeddings::EmbeddingStore;

--- a/src/algos/ep/model.rs
+++ b/src/algos/ep/model.rs
@@ -1,7 +1,7 @@
 //! The Embedding Propagation framework parameterizes over the feature aggregator - that is, given
 //! a node with a set of features, how do we combine them to product a node embedding?
 //! This module defines them
-use simple_grad::*;
+use crate::autograd::*;
 use hashbrown::HashMap;
 use rand::prelude::*;
 
@@ -461,4 +461,3 @@ pub fn mean_embeddings<'a>(
     });
     vs.sum_all() / n as f32
 }
-

--- a/src/algos/pprrank.rs
+++ b/src/algos/pprrank.rs
@@ -8,7 +8,7 @@ use hashbrown::HashMap;
 use std::collections::{HashMap as CHashMap};
 use rand::prelude::*;
 use rand_xorshift::XorShiftRng;
-use simple_grad::*;
+use crate::autograd::*;
 
 use crate::algos::rwr::RWR;
 use crate::algos::utils::Sample;

--- a/src/autograd.rs
+++ b/src/autograd.rs
@@ -10,17 +10,23 @@ fn unwrap_tensor(result: candle_core::Result<Tensor>, context: &str) -> Tensor {
 fn device() -> &'static Device {
     static DEVICE: OnceLock<Device> = OnceLock::new();
     DEVICE.get_or_init(|| {
-        #[cfg(feature = "metal")]
+        #[cfg(feature = "cuda")]
+        {
+            return Device::new_cuda(0).expect("Candle CUDA device");
+        }
+
+        #[cfg(all(not(feature = "cuda"), feature = "metal"))]
         {
             return Device::new_metal(0).expect("Candle Metal device");
         }
 
-        #[cfg(not(feature = "metal"))]
+        #[cfg(all(not(feature = "cuda"), not(feature = "metal")))]
         {
             Device::Cpu
         }
     })
 }
+
 
 #[derive(Clone)]
 pub struct ANode {

--- a/src/autograd.rs
+++ b/src/autograd.rs
@@ -199,6 +199,40 @@ fn scalar_op(
     ANode::from_tensor(unwrap_tensor(op(lhs.as_tensor(), rhs as f64), context))
 }
 
+
+impl Div<ANode> for f32 {
+    type Output = ANode;
+
+    fn div(self, rhs: ANode) -> Self::Output {
+        Constant::scalar(self) / rhs
+    }
+}
+
+impl Div<&ANode> for f32 {
+    type Output = ANode;
+
+    fn div(self, rhs: &ANode) -> Self::Output {
+        Constant::scalar(self) / rhs
+    }
+}
+
+impl Neg for ANode {
+    type Output = ANode;
+
+    fn neg(self) -> Self::Output {
+        scalar_op(&self, 0.0, |lhs, _| lhs.affine(-1.0, 0.0), "neg")
+    }
+}
+
+impl Neg for &ANode {
+    type Output = ANode;
+
+    fn neg(self) -> Self::Output {
+        scalar_op(self, 0.0, |lhs, _| lhs.affine(-1.0, 0.0), "neg")
+    }
+}
+
+
 macro_rules! impl_binary_op {
     ($trait:ident, $method:ident, $tensor_op:path, $context:literal) => {
         impl $trait for ANode {
@@ -295,46 +329,6 @@ macro_rules! impl_scalar_lhs_op {
     };
 }
 
-macro_rules! impl_scalar_lhs_via_constant_op {
-    ($trait:ident, $method:ident, $op:tt) => {
-        impl $trait<ANode> for f32 {
-            type Output = ANode;
-
-            fn $method(self, rhs: ANode) -> Self::Output {
-                Constant::scalar(self) $op rhs
-            }
-        }
-
-        impl $trait<&ANode> for f32 {
-            type Output = ANode;
-
-            fn $method(self, rhs: &ANode) -> Self::Output {
-                Constant::scalar(self) $op rhs
-            }
-        }
-    };
-}
-
-macro_rules! impl_unary_op {
-    ($trait:ident, $method:ident, $op:expr, $context:literal) => {
-        impl $trait for ANode {
-            type Output = ANode;
-
-            fn $method(self) -> Self::Output {
-                scalar_op(&self, 0.0, $op, $context)
-            }
-        }
-
-        impl $trait for &ANode {
-            type Output = ANode;
-
-            fn $method(self) -> Self::Output {
-                scalar_op(self, 0.0, $op, $context)
-            }
-        }
-    };
-}
-
 impl_binary_op!(Add, add, Tensor::broadcast_add, "add");
 impl_scalar_rhs_op!(Add, add, |lhs, s| lhs.affine(1.0, s), "add scalar");
 impl_commutative_scalar_lhs_op!(Add, add, +);
@@ -349,6 +343,3 @@ impl_commutative_scalar_lhs_op!(Mul, mul, *);
 
 impl_binary_op!(Div, div, Tensor::broadcast_div, "div");
 impl_scalar_rhs_op!(Div, div, |lhs, s| lhs.affine(1.0 / s, 0.0), "div scalar");
-impl_scalar_lhs_via_constant_op!(Div, div, /);
-
-impl_unary_op!(Neg, neg, |lhs, _| lhs.affine(-1.0, 0.0), "neg");

--- a/src/autograd.rs
+++ b/src/autograd.rs
@@ -1,9 +1,25 @@
 use std::ops::{Add, Div, Mul, Neg, Sub};
+use std::sync::OnceLock;
 
 use candle_core::{backprop::GradStore, Device, Tensor, Var};
 
 fn unwrap_tensor(result: candle_core::Result<Tensor>, context: &str) -> Tensor {
     result.unwrap_or_else(|err| panic!("Candle autograd error in {context}: {err}"))
+}
+
+fn device() -> &'static Device {
+    static DEVICE: OnceLock<Device> = OnceLock::new();
+    DEVICE.get_or_init(|| {
+        #[cfg(feature = "metal")]
+        {
+            return Device::new_metal(0).expect("Candle Metal device");
+        }
+
+        #[cfg(not(feature = "metal"))]
+        {
+            Device::Cpu
+        }
+    })
 }
 
 #[derive(Clone)]
@@ -81,7 +97,7 @@ impl Variable {
     }
 
     pub fn pooled(data: &[f32]) -> ANode {
-        let var = Var::from_slice(data, data.len(), &Device::Cpu).expect("Candle variable");
+        let var = Var::from_slice(data, data.len(), device()).expect("Candle variable");
         ANode::from_tensor(var.into_inner())
     }
 }
@@ -91,13 +107,13 @@ pub struct Constant;
 impl Constant {
     pub fn new(data: Vec<f32>) -> ANode {
         ANode::from_tensor(
-            Tensor::from_slice(data.as_slice(), data.len(), &Device::Cpu).expect("Candle constant"),
+            Tensor::from_slice(data.as_slice(), data.len(), device()).expect("Candle constant"),
         )
     }
 
     pub fn scalar(value: f32) -> ANode {
         ANode::from_tensor(
-            Tensor::from_slice(&[value], 1, &Device::Cpu).expect("Candle scalar constant"),
+            Tensor::from_slice(&[value], 1, device()).expect("Candle scalar constant"),
         )
     }
 }

--- a/src/autograd.rs
+++ b/src/autograd.rs
@@ -181,282 +181,174 @@ impl ANodeVecOps for Vec<ANode> {
     }
 }
 
-fn binary_op(lhs: &ANode, rhs: &ANode, op: fn(&Tensor, &Tensor) -> candle_core::Result<Tensor>, context: &str) -> ANode {
+fn binary_op(
+    lhs: &ANode,
+    rhs: &ANode,
+    op: fn(&Tensor, &Tensor) -> candle_core::Result<Tensor>,
+    context: &str,
+) -> ANode {
     ANode::from_tensor(unwrap_tensor(op(lhs.as_tensor(), rhs.as_tensor()), context))
 }
 
-fn scalar_op(lhs: &ANode, rhs: f32, op: fn(&Tensor, f64) -> candle_core::Result<Tensor>, context: &str) -> ANode {
+fn scalar_op(
+    lhs: &ANode,
+    rhs: f32,
+    op: fn(&Tensor, f64) -> candle_core::Result<Tensor>,
+    context: &str,
+) -> ANode {
     ANode::from_tensor(unwrap_tensor(op(lhs.as_tensor(), rhs as f64), context))
 }
 
-impl Add for ANode {
-    type Output = ANode;
+macro_rules! impl_binary_op {
+    ($trait:ident, $method:ident, $tensor_op:path, $context:literal) => {
+        impl $trait for ANode {
+            type Output = ANode;
 
-    fn add(self, rhs: Self) -> Self::Output {
-        binary_op(&self, &rhs, Tensor::broadcast_add, "add")
-    }
+            fn $method(self, rhs: Self) -> Self::Output {
+                binary_op(&self, &rhs, $tensor_op, $context)
+            }
+        }
+
+        impl $trait<&ANode> for ANode {
+            type Output = ANode;
+
+            fn $method(self, rhs: &ANode) -> Self::Output {
+                binary_op(&self, rhs, $tensor_op, $context)
+            }
+        }
+
+        impl $trait<ANode> for &ANode {
+            type Output = ANode;
+
+            fn $method(self, rhs: ANode) -> Self::Output {
+                binary_op(self, &rhs, $tensor_op, $context)
+            }
+        }
+
+        impl $trait<&ANode> for &ANode {
+            type Output = ANode;
+
+            fn $method(self, rhs: &ANode) -> Self::Output {
+                binary_op(self, rhs, $tensor_op, $context)
+            }
+        }
+    };
 }
 
-impl Add<&ANode> for ANode {
-    type Output = ANode;
+macro_rules! impl_scalar_rhs_op {
+    ($trait:ident, $method:ident, $op:expr, $context:literal) => {
+        impl $trait<f32> for ANode {
+            type Output = ANode;
 
-    fn add(self, rhs: &ANode) -> Self::Output {
-        binary_op(&self, rhs, Tensor::broadcast_add, "add")
-    }
+            fn $method(self, rhs: f32) -> Self::Output {
+                scalar_op(&self, rhs, $op, $context)
+            }
+        }
+
+        impl $trait<f32> for &ANode {
+            type Output = ANode;
+
+            fn $method(self, rhs: f32) -> Self::Output {
+                scalar_op(self, rhs, $op, $context)
+            }
+        }
+    };
 }
 
-impl Add<ANode> for &ANode {
-    type Output = ANode;
+macro_rules! impl_commutative_scalar_lhs_op {
+    ($trait:ident, $method:ident, $op:tt) => {
+        impl $trait<ANode> for f32 {
+            type Output = ANode;
 
-    fn add(self, rhs: ANode) -> Self::Output {
-        binary_op(self, &rhs, Tensor::broadcast_add, "add")
-    }
+            fn $method(self, rhs: ANode) -> Self::Output {
+                rhs $op self
+            }
+        }
+
+        impl $trait<&ANode> for f32 {
+            type Output = ANode;
+
+            fn $method(self, rhs: &ANode) -> Self::Output {
+                rhs $op self
+            }
+        }
+    };
 }
 
-impl Add<&ANode> for &ANode {
-    type Output = ANode;
+macro_rules! impl_scalar_lhs_op {
+    ($trait:ident, $method:ident, $op:expr, $context:literal) => {
+        impl $trait<ANode> for f32 {
+            type Output = ANode;
 
-    fn add(self, rhs: &ANode) -> Self::Output {
-        binary_op(self, rhs, Tensor::broadcast_add, "add")
-    }
+            fn $method(self, rhs: ANode) -> Self::Output {
+                scalar_op(&rhs, self, $op, $context)
+            }
+        }
+
+        impl $trait<&ANode> for f32 {
+            type Output = ANode;
+
+            fn $method(self, rhs: &ANode) -> Self::Output {
+                scalar_op(rhs, self, $op, $context)
+            }
+        }
+    };
 }
 
-impl Add<f32> for ANode {
-    type Output = ANode;
+macro_rules! impl_scalar_lhs_via_constant_op {
+    ($trait:ident, $method:ident, $op:tt) => {
+        impl $trait<ANode> for f32 {
+            type Output = ANode;
 
-    fn add(self, rhs: f32) -> Self::Output {
-        scalar_op(&self, rhs, |lhs, s| lhs.affine(1.0, s), "add scalar")
-    }
+            fn $method(self, rhs: ANode) -> Self::Output {
+                Constant::scalar(self) $op rhs
+            }
+        }
+
+        impl $trait<&ANode> for f32 {
+            type Output = ANode;
+
+            fn $method(self, rhs: &ANode) -> Self::Output {
+                Constant::scalar(self) $op rhs
+            }
+        }
+    };
 }
 
-impl Add<f32> for &ANode {
-    type Output = ANode;
+macro_rules! impl_unary_op {
+    ($trait:ident, $method:ident, $op:expr, $context:literal) => {
+        impl $trait for ANode {
+            type Output = ANode;
 
-    fn add(self, rhs: f32) -> Self::Output {
-        scalar_op(self, rhs, |lhs, s| lhs.affine(1.0, s), "add scalar")
-    }
+            fn $method(self) -> Self::Output {
+                scalar_op(&self, 0.0, $op, $context)
+            }
+        }
+
+        impl $trait for &ANode {
+            type Output = ANode;
+
+            fn $method(self) -> Self::Output {
+                scalar_op(self, 0.0, $op, $context)
+            }
+        }
+    };
 }
 
-impl Add<ANode> for f32 {
-    type Output = ANode;
+impl_binary_op!(Add, add, Tensor::broadcast_add, "add");
+impl_scalar_rhs_op!(Add, add, |lhs, s| lhs.affine(1.0, s), "add scalar");
+impl_commutative_scalar_lhs_op!(Add, add, +);
 
-    fn add(self, rhs: ANode) -> Self::Output {
-        rhs + self
-    }
-}
+impl_binary_op!(Sub, sub, Tensor::broadcast_sub, "sub");
+impl_scalar_rhs_op!(Sub, sub, |lhs, s| lhs.affine(1.0, -s), "sub scalar");
+impl_scalar_lhs_op!(Sub, sub, |lhs, s| lhs.affine(-1.0, s), "scalar sub");
 
-impl Add<&ANode> for f32 {
-    type Output = ANode;
+impl_binary_op!(Mul, mul, Tensor::broadcast_mul, "mul");
+impl_scalar_rhs_op!(Mul, mul, |lhs, s| lhs.affine(s, 0.0), "mul scalar");
+impl_commutative_scalar_lhs_op!(Mul, mul, *);
 
-    fn add(self, rhs: &ANode) -> Self::Output {
-        rhs + self
-    }
-}
+impl_binary_op!(Div, div, Tensor::broadcast_div, "div");
+impl_scalar_rhs_op!(Div, div, |lhs, s| lhs.affine(1.0 / s, 0.0), "div scalar");
+impl_scalar_lhs_via_constant_op!(Div, div, /);
 
-impl Sub for ANode {
-    type Output = ANode;
-
-    fn sub(self, rhs: Self) -> Self::Output {
-        binary_op(&self, &rhs, Tensor::broadcast_sub, "sub")
-    }
-}
-
-impl Sub<&ANode> for ANode {
-    type Output = ANode;
-
-    fn sub(self, rhs: &ANode) -> Self::Output {
-        binary_op(&self, rhs, Tensor::broadcast_sub, "sub")
-    }
-}
-
-impl Sub<ANode> for &ANode {
-    type Output = ANode;
-
-    fn sub(self, rhs: ANode) -> Self::Output {
-        binary_op(self, &rhs, Tensor::broadcast_sub, "sub")
-    }
-}
-
-impl Sub<&ANode> for &ANode {
-    type Output = ANode;
-
-    fn sub(self, rhs: &ANode) -> Self::Output {
-        binary_op(self, rhs, Tensor::broadcast_sub, "sub")
-    }
-}
-
-impl Sub<f32> for ANode {
-    type Output = ANode;
-
-    fn sub(self, rhs: f32) -> Self::Output {
-        scalar_op(&self, rhs, |lhs, s| lhs.affine(1.0, -s), "sub scalar")
-    }
-}
-
-impl Sub<f32> for &ANode {
-    type Output = ANode;
-
-    fn sub(self, rhs: f32) -> Self::Output {
-        scalar_op(self, rhs, |lhs, s| lhs.affine(1.0, -s), "sub scalar")
-    }
-}
-
-impl Sub<ANode> for f32 {
-    type Output = ANode;
-
-    fn sub(self, rhs: ANode) -> Self::Output {
-        scalar_op(&rhs, self, |lhs, s| lhs.affine(-1.0, s), "scalar sub")
-    }
-}
-
-impl Sub<&ANode> for f32 {
-    type Output = ANode;
-
-    fn sub(self, rhs: &ANode) -> Self::Output {
-        scalar_op(rhs, self, |lhs, s| lhs.affine(-1.0, s), "scalar sub")
-    }
-}
-
-impl Mul for ANode {
-    type Output = ANode;
-
-    fn mul(self, rhs: Self) -> Self::Output {
-        binary_op(&self, &rhs, Tensor::broadcast_mul, "mul")
-    }
-}
-
-impl Mul<&ANode> for ANode {
-    type Output = ANode;
-
-    fn mul(self, rhs: &ANode) -> Self::Output {
-        binary_op(&self, rhs, Tensor::broadcast_mul, "mul")
-    }
-}
-
-impl Mul<ANode> for &ANode {
-    type Output = ANode;
-
-    fn mul(self, rhs: ANode) -> Self::Output {
-        binary_op(self, &rhs, Tensor::broadcast_mul, "mul")
-    }
-}
-
-impl Mul<&ANode> for &ANode {
-    type Output = ANode;
-
-    fn mul(self, rhs: &ANode) -> Self::Output {
-        binary_op(self, rhs, Tensor::broadcast_mul, "mul")
-    }
-}
-
-impl Mul<f32> for ANode {
-    type Output = ANode;
-
-    fn mul(self, rhs: f32) -> Self::Output {
-        scalar_op(&self, rhs, |lhs, s| lhs.affine(s, 0.0), "mul scalar")
-    }
-}
-
-impl Mul<f32> for &ANode {
-    type Output = ANode;
-
-    fn mul(self, rhs: f32) -> Self::Output {
-        scalar_op(self, rhs, |lhs, s| lhs.affine(s, 0.0), "mul scalar")
-    }
-}
-
-impl Mul<ANode> for f32 {
-    type Output = ANode;
-
-    fn mul(self, rhs: ANode) -> Self::Output {
-        rhs * self
-    }
-}
-
-impl Mul<&ANode> for f32 {
-    type Output = ANode;
-
-    fn mul(self, rhs: &ANode) -> Self::Output {
-        rhs * self
-    }
-}
-
-impl Div for ANode {
-    type Output = ANode;
-
-    fn div(self, rhs: Self) -> Self::Output {
-        binary_op(&self, &rhs, Tensor::broadcast_div, "div")
-    }
-}
-
-impl Div<&ANode> for ANode {
-    type Output = ANode;
-
-    fn div(self, rhs: &ANode) -> Self::Output {
-        binary_op(&self, rhs, Tensor::broadcast_div, "div")
-    }
-}
-
-impl Div<ANode> for &ANode {
-    type Output = ANode;
-
-    fn div(self, rhs: ANode) -> Self::Output {
-        binary_op(self, &rhs, Tensor::broadcast_div, "div")
-    }
-}
-
-impl Div<&ANode> for &ANode {
-    type Output = ANode;
-
-    fn div(self, rhs: &ANode) -> Self::Output {
-        binary_op(self, rhs, Tensor::broadcast_div, "div")
-    }
-}
-
-impl Div<f32> for ANode {
-    type Output = ANode;
-
-    fn div(self, rhs: f32) -> Self::Output {
-        scalar_op(&self, rhs, |lhs, s| lhs.affine(1.0 / s, 0.0), "div scalar")
-    }
-}
-
-impl Div<f32> for &ANode {
-    type Output = ANode;
-
-    fn div(self, rhs: f32) -> Self::Output {
-        scalar_op(self, rhs, |lhs, s| lhs.affine(1.0 / s, 0.0), "div scalar")
-    }
-}
-
-impl Div<ANode> for f32 {
-    type Output = ANode;
-
-    fn div(self, rhs: ANode) -> Self::Output {
-        Constant::scalar(self) / rhs
-    }
-}
-
-impl Div<&ANode> for f32 {
-    type Output = ANode;
-
-    fn div(self, rhs: &ANode) -> Self::Output {
-        Constant::scalar(self) / rhs
-    }
-}
-
-impl Neg for ANode {
-    type Output = ANode;
-
-    fn neg(self) -> Self::Output {
-        scalar_op(&self, 0.0, |lhs, _| lhs.affine(-1.0, 0.0), "neg")
-    }
-}
-
-impl Neg for &ANode {
-    type Output = ANode;
-
-    fn neg(self) -> Self::Output {
-        scalar_op(self, 0.0, |lhs, _| lhs.affine(-1.0, 0.0), "neg")
-    }
-}
+impl_unary_op!(Neg, neg, |lhs, _| lhs.affine(-1.0, 0.0), "neg");

--- a/src/autograd.rs
+++ b/src/autograd.rs
@@ -1,0 +1,446 @@
+use std::ops::{Add, Div, Mul, Neg, Sub};
+
+use candle_core::{backprop::GradStore, Device, Tensor, Var};
+
+fn unwrap_tensor(result: candle_core::Result<Tensor>, context: &str) -> Tensor {
+    result.unwrap_or_else(|err| panic!("Candle autograd error in {context}: {err}"))
+}
+
+#[derive(Clone)]
+pub struct ANode {
+    tensor: Tensor,
+}
+
+impl ANode {
+    fn from_tensor(tensor: Tensor) -> Self {
+        Self { tensor }
+    }
+
+    fn as_tensor(&self) -> &Tensor {
+        &self.tensor
+    }
+
+    pub fn value(&self) -> Vec<f32> {
+        if self.tensor.rank() == 0 {
+            vec![self.tensor.to_scalar::<f32>().expect("Candle scalar value")]
+        } else {
+            self.tensor.to_vec1::<f32>().expect("Candle 1d value")
+        }
+    }
+
+    pub fn slice(&self, start: usize, len: usize) -> Self {
+        Self::from_tensor(unwrap_tensor(self.tensor.narrow(0, start, len), "slice"))
+    }
+
+    pub fn dot(&self, rhs: &Self) -> Self {
+        Self::from_tensor(unwrap_tensor(
+            unwrap_tensor((&self.tensor).mul(rhs.as_tensor()), "dot mul").sum_all(),
+            "dot sum",
+        ))
+    }
+
+    pub fn sum(&self) -> Self {
+        Self::from_tensor(unwrap_tensor(self.tensor.sum_all(), "sum"))
+    }
+
+    pub fn pow(&self, exp: f32) -> Self {
+        Self::from_tensor(unwrap_tensor(self.tensor.powf(exp as f64), "pow"))
+    }
+
+    pub fn sqrt(&self) -> Self {
+        Self::from_tensor(unwrap_tensor(self.tensor.sqrt(), "sqrt"))
+    }
+
+    pub fn exp(&self) -> Self {
+        Self::from_tensor(unwrap_tensor(self.tensor.exp(), "exp"))
+    }
+
+    pub fn exp_approx(&self) -> Self {
+        self.exp()
+    }
+
+    pub fn ln(&self) -> Self {
+        Self::from_tensor(unwrap_tensor(self.tensor.log(), "ln"))
+    }
+
+    pub fn tanh(&self) -> Self {
+        Self::from_tensor(unwrap_tensor(self.tensor.tanh(), "tanh"))
+    }
+
+    pub fn maximum(&self, min: f32) -> Self {
+        Self::from_tensor(unwrap_tensor(self.tensor.maximum(min as f64), "maximum"))
+    }
+}
+
+pub struct Variable;
+
+impl Variable {
+    #[cfg(test)]
+    pub fn new(data: Vec<f32>) -> ANode {
+        Self::pooled(data.as_slice())
+    }
+
+    pub fn pooled(data: &[f32]) -> ANode {
+        let var = Var::from_slice(data, data.len(), &Device::Cpu).expect("Candle variable");
+        ANode::from_tensor(var.into_inner())
+    }
+}
+
+pub struct Constant;
+
+impl Constant {
+    pub fn new(data: Vec<f32>) -> ANode {
+        ANode::from_tensor(
+            Tensor::from_slice(data.as_slice(), data.len(), &Device::Cpu).expect("Candle constant"),
+        )
+    }
+
+    pub fn scalar(value: f32) -> ANode {
+        ANode::from_tensor(
+            Tensor::from_slice(&[value], 1, &Device::Cpu).expect("Candle scalar constant"),
+        )
+    }
+}
+
+pub struct Graph {
+    grads: Option<GradStore>,
+}
+
+impl Graph {
+    pub fn new() -> Self {
+        Self { grads: None }
+    }
+
+    pub fn backward(&mut self, loss: &ANode) {
+        self.grads = Some(loss.as_tensor().backward().expect("Candle backward"));
+    }
+
+    pub fn get_grad(&self, node: &ANode) -> Option<Vec<f32>> {
+        self.grads
+            .as_ref()
+            .and_then(|grads| grads.get(node.as_tensor()))
+            .map(|grad| {
+                if grad.rank() == 0 {
+                    vec![grad.to_scalar::<f32>().expect("Candle scalar gradient")]
+                } else {
+                    grad.to_vec1::<f32>().expect("Candle 1d gradient")
+                }
+            })
+    }
+
+    pub fn print_graph(_loss: &ANode) {}
+}
+
+pub fn use_shared_pool(_enabled: bool) {}
+
+pub trait ANodeVecOps {
+    fn sum_all(self) -> ANode;
+    fn concat(self) -> ANode;
+}
+
+impl ANodeVecOps for Vec<ANode> {
+    fn sum_all(self) -> ANode {
+        let mut it = self.into_iter();
+        let first = it.next().unwrap_or_else(|| Constant::scalar(0.0));
+        it.fold(first, |acc, node| acc + node)
+    }
+
+    fn concat(self) -> ANode {
+        let tensors = self
+            .iter()
+            .map(|node| {
+                if node.as_tensor().rank() == 0 {
+                    unwrap_tensor(node.as_tensor().reshape(1), "concat scalar reshape")
+                } else {
+                    node.as_tensor().clone()
+                }
+            })
+            .collect::<Vec<_>>();
+
+        if tensors.is_empty() {
+            return Constant::new(Vec::new());
+        }
+
+        ANode::from_tensor(unwrap_tensor(Tensor::cat(&tensors, 0), "concat"))
+    }
+}
+
+fn binary_op(lhs: &ANode, rhs: &ANode, op: fn(&Tensor, &Tensor) -> candle_core::Result<Tensor>, context: &str) -> ANode {
+    ANode::from_tensor(unwrap_tensor(op(lhs.as_tensor(), rhs.as_tensor()), context))
+}
+
+fn scalar_op(lhs: &ANode, rhs: f32, op: fn(&Tensor, f64) -> candle_core::Result<Tensor>, context: &str) -> ANode {
+    ANode::from_tensor(unwrap_tensor(op(lhs.as_tensor(), rhs as f64), context))
+}
+
+impl Add for ANode {
+    type Output = ANode;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        binary_op(&self, &rhs, Tensor::broadcast_add, "add")
+    }
+}
+
+impl Add<&ANode> for ANode {
+    type Output = ANode;
+
+    fn add(self, rhs: &ANode) -> Self::Output {
+        binary_op(&self, rhs, Tensor::broadcast_add, "add")
+    }
+}
+
+impl Add<ANode> for &ANode {
+    type Output = ANode;
+
+    fn add(self, rhs: ANode) -> Self::Output {
+        binary_op(self, &rhs, Tensor::broadcast_add, "add")
+    }
+}
+
+impl Add<&ANode> for &ANode {
+    type Output = ANode;
+
+    fn add(self, rhs: &ANode) -> Self::Output {
+        binary_op(self, rhs, Tensor::broadcast_add, "add")
+    }
+}
+
+impl Add<f32> for ANode {
+    type Output = ANode;
+
+    fn add(self, rhs: f32) -> Self::Output {
+        scalar_op(&self, rhs, |lhs, s| lhs.affine(1.0, s), "add scalar")
+    }
+}
+
+impl Add<f32> for &ANode {
+    type Output = ANode;
+
+    fn add(self, rhs: f32) -> Self::Output {
+        scalar_op(self, rhs, |lhs, s| lhs.affine(1.0, s), "add scalar")
+    }
+}
+
+impl Add<ANode> for f32 {
+    type Output = ANode;
+
+    fn add(self, rhs: ANode) -> Self::Output {
+        rhs + self
+    }
+}
+
+impl Add<&ANode> for f32 {
+    type Output = ANode;
+
+    fn add(self, rhs: &ANode) -> Self::Output {
+        rhs + self
+    }
+}
+
+impl Sub for ANode {
+    type Output = ANode;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        binary_op(&self, &rhs, Tensor::broadcast_sub, "sub")
+    }
+}
+
+impl Sub<&ANode> for ANode {
+    type Output = ANode;
+
+    fn sub(self, rhs: &ANode) -> Self::Output {
+        binary_op(&self, rhs, Tensor::broadcast_sub, "sub")
+    }
+}
+
+impl Sub<ANode> for &ANode {
+    type Output = ANode;
+
+    fn sub(self, rhs: ANode) -> Self::Output {
+        binary_op(self, &rhs, Tensor::broadcast_sub, "sub")
+    }
+}
+
+impl Sub<&ANode> for &ANode {
+    type Output = ANode;
+
+    fn sub(self, rhs: &ANode) -> Self::Output {
+        binary_op(self, rhs, Tensor::broadcast_sub, "sub")
+    }
+}
+
+impl Sub<f32> for ANode {
+    type Output = ANode;
+
+    fn sub(self, rhs: f32) -> Self::Output {
+        scalar_op(&self, rhs, |lhs, s| lhs.affine(1.0, -s), "sub scalar")
+    }
+}
+
+impl Sub<f32> for &ANode {
+    type Output = ANode;
+
+    fn sub(self, rhs: f32) -> Self::Output {
+        scalar_op(self, rhs, |lhs, s| lhs.affine(1.0, -s), "sub scalar")
+    }
+}
+
+impl Sub<ANode> for f32 {
+    type Output = ANode;
+
+    fn sub(self, rhs: ANode) -> Self::Output {
+        scalar_op(&rhs, self, |lhs, s| lhs.affine(-1.0, s), "scalar sub")
+    }
+}
+
+impl Sub<&ANode> for f32 {
+    type Output = ANode;
+
+    fn sub(self, rhs: &ANode) -> Self::Output {
+        scalar_op(rhs, self, |lhs, s| lhs.affine(-1.0, s), "scalar sub")
+    }
+}
+
+impl Mul for ANode {
+    type Output = ANode;
+
+    fn mul(self, rhs: Self) -> Self::Output {
+        binary_op(&self, &rhs, Tensor::broadcast_mul, "mul")
+    }
+}
+
+impl Mul<&ANode> for ANode {
+    type Output = ANode;
+
+    fn mul(self, rhs: &ANode) -> Self::Output {
+        binary_op(&self, rhs, Tensor::broadcast_mul, "mul")
+    }
+}
+
+impl Mul<ANode> for &ANode {
+    type Output = ANode;
+
+    fn mul(self, rhs: ANode) -> Self::Output {
+        binary_op(self, &rhs, Tensor::broadcast_mul, "mul")
+    }
+}
+
+impl Mul<&ANode> for &ANode {
+    type Output = ANode;
+
+    fn mul(self, rhs: &ANode) -> Self::Output {
+        binary_op(self, rhs, Tensor::broadcast_mul, "mul")
+    }
+}
+
+impl Mul<f32> for ANode {
+    type Output = ANode;
+
+    fn mul(self, rhs: f32) -> Self::Output {
+        scalar_op(&self, rhs, |lhs, s| lhs.affine(s, 0.0), "mul scalar")
+    }
+}
+
+impl Mul<f32> for &ANode {
+    type Output = ANode;
+
+    fn mul(self, rhs: f32) -> Self::Output {
+        scalar_op(self, rhs, |lhs, s| lhs.affine(s, 0.0), "mul scalar")
+    }
+}
+
+impl Mul<ANode> for f32 {
+    type Output = ANode;
+
+    fn mul(self, rhs: ANode) -> Self::Output {
+        rhs * self
+    }
+}
+
+impl Mul<&ANode> for f32 {
+    type Output = ANode;
+
+    fn mul(self, rhs: &ANode) -> Self::Output {
+        rhs * self
+    }
+}
+
+impl Div for ANode {
+    type Output = ANode;
+
+    fn div(self, rhs: Self) -> Self::Output {
+        binary_op(&self, &rhs, Tensor::broadcast_div, "div")
+    }
+}
+
+impl Div<&ANode> for ANode {
+    type Output = ANode;
+
+    fn div(self, rhs: &ANode) -> Self::Output {
+        binary_op(&self, rhs, Tensor::broadcast_div, "div")
+    }
+}
+
+impl Div<ANode> for &ANode {
+    type Output = ANode;
+
+    fn div(self, rhs: ANode) -> Self::Output {
+        binary_op(self, &rhs, Tensor::broadcast_div, "div")
+    }
+}
+
+impl Div<&ANode> for &ANode {
+    type Output = ANode;
+
+    fn div(self, rhs: &ANode) -> Self::Output {
+        binary_op(self, rhs, Tensor::broadcast_div, "div")
+    }
+}
+
+impl Div<f32> for ANode {
+    type Output = ANode;
+
+    fn div(self, rhs: f32) -> Self::Output {
+        scalar_op(&self, rhs, |lhs, s| lhs.affine(1.0 / s, 0.0), "div scalar")
+    }
+}
+
+impl Div<f32> for &ANode {
+    type Output = ANode;
+
+    fn div(self, rhs: f32) -> Self::Output {
+        scalar_op(self, rhs, |lhs, s| lhs.affine(1.0 / s, 0.0), "div scalar")
+    }
+}
+
+impl Div<ANode> for f32 {
+    type Output = ANode;
+
+    fn div(self, rhs: ANode) -> Self::Output {
+        Constant::scalar(self) / rhs
+    }
+}
+
+impl Div<&ANode> for f32 {
+    type Output = ANode;
+
+    fn div(self, rhs: &ANode) -> Self::Output {
+        Constant::scalar(self) / rhs
+    }
+}
+
+impl Neg for ANode {
+    type Output = ANode;
+
+    fn neg(self) -> Self::Output {
+        scalar_op(&self, 0.0, |lhs, _| lhs.affine(-1.0, 0.0), "neg")
+    }
+}
+
+impl Neg for &ANode {
+    type Output = ANode;
+
+    fn neg(self) -> Self::Output {
+        scalar_op(self, 0.0, |lhs, _| lhs.affine(-1.0, 0.0), "neg")
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,8 @@ pub mod graph;
 /// We define all the algorithms within this module
 pub mod algos;
 
+mod autograd;
+
 /// How can we efficiently sample from the graph?
 mod sampler;
 
@@ -5087,4 +5089,3 @@ fn cloverleaf(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_class::<PolicyEvaluation>()?;
     Ok(())
 }
-


### PR DESCRIPTION
This change adds a small adaptor for autograd, that removes SimpleGrad in favor of using Candle. We introduce a small adaptor interface that simply calls out to Candle on the backend, and preserves the SimpleGrad api.

Bonus: you can swap the device for CPU/Metal/Cuda (Metal is MacOS only).

To compile for cuda you must specify compute capability e.g.:

```
CUDA_COMPUTE_CAP=120 maturin develop --release --features=cuda
```