### PR TITLE
Document CPU/CUDA build options, mark CUDA as experimental

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2021"
 default = []
 accelerate = ["candle-core/accelerate"]
 metal = ["candle-core/metal"]
+# Experimental: the CUDA backend works end-to-end but is currently slower than
+# the CPU backend on typical Cloverleaf workloads. See README for build notes.
 cuda = ["candle-core/cuda"]
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -28,8 +28,30 @@ The library is broken up into a few different methods:
 1. Create a new python virtualenv
 2. `pip install maturin numpy`
 3. Ensure you have the latest Rust compiler
-4. `RUSTFLAGS="-C target-cpu=native" maturin develop --release`
+4. Build the extension. The autograd backend is the [Candle](https://github.com/huggingface/candle) tensor library; by default it runs on CPU:
+
+    ```
+    RUSTFLAGS="-C target-cpu=native" maturin develop --release
+    ```
+
 5. Profit!
+
+### Experimental CUDA support
+
+Cloverleaf can also be built with Candle's CUDA backend. This is **experimental** — the CPU path is the supported path and is faster than the CUDA path on most workloads at typical Cloverleaf sizes. The CUDA build is useful as a starting point if you want to experiment with GPU acceleration, but it is not yet production-ready.
+
+To build with CUDA, you need:
+
+- A working CUDA toolkit (`nvcc`, headers, runtime libs) on `PATH` / `LD_LIBRARY_PATH`.
+- The `CUDA_COMPUTE_CAP` env var set to your GPU's compute capability (e.g. `120` for SM 12.0 / Blackwell-class, `89` for SM 8.9 / Ada). This is read by the underlying `cudarc` build script.
+- Pass `--features cuda` to maturin so the `cuda` feature gets propagated to `candle-core`:
+
+    ```
+    CUDA_COMPUTE_CAP=120 RUSTFLAGS="-C target-cpu=native" \
+        maturin develop --release --features cuda
+    ```
+
+The resulting binary places all autograd tensors on the GPU. If you find the CUDA path slower than CPU for your workload, fall back to the plain (no-`--features`) build above — the CPU build does not link any CUDA libraries.
 
 ## Data Format
 


### PR DESCRIPTION
## Summary

Follow-up to #24 (the Candle migration). Adds README guidance for the two build configurations and flags the CUDA backend as experimental.

- README's **Installation** section keeps the default CPU build front-and-center and adds an **Experimental CUDA support** subsection covering the \`CUDA_COMPUTE_CAP\` env var and the \`--features cuda\` flag that need to be passed through to maturin so the cuda feature actually propagates to candle-core.
- \`Cargo.toml\` gets a one-line comment above the \`cuda\` feature noting it's experimental and slower than CPU on typical Cloverleaf workloads (per our bench grid: branch CUDA up to 5× slower than branch CPU at n=16384/d=256; CPU build itself is competitive with — sometimes faster than — pre-Candle main).

No code changes outside docs + the Cargo.toml comment.

## Test plan

- [ ] \`cargo build --release --lib\` clean
- [ ] \`maturin develop --release\` (default CPU build) installs and imports
- [ ] \`CUDA_COMPUTE_CAP=<cap> maturin develop --release --features cuda\` produces a CUDA-linked .so (verifiable via \`ldd\` showing \`libcudart\` / \`libcublas\`)